### PR TITLE
Upgrade to v3.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Collaborative editing in real-time
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://etherpad.org/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://video.etherpad.com/)
-[![Version: 3.2.0~ynh1](https://img.shields.io/badge/Version-3.2.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/etherpad/)
+[![Version: 3.3.0~ynh1](https://img.shields.io/badge/Version-3.3.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/etherpad/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/etherpad"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Collaborative editing in real-time
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://etherpad.org/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://video.etherpad.com/)
-[![Version: 3.3.0~ynh1](https://img.shields.io/badge/Version-3.3.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/etherpad/)
+[![Version: 3.3.1~ynh1](https://img.shields.io/badge/Version-3.3.1~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/etherpad/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/etherpad"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -15,11 +15,11 @@ maintainers = ["eric_G"]
 license = "Apache-2.0"
 website = "https://etherpad.org/"
 demo = "https://video.etherpad.com/"
-admindoc = "https://etherpad.org/doc/v2.2.7/"
+admindoc = "https://etherpad.org/doc/v3.3.1/index.html"
 code = "https://github.com/ether/etherpad-lite"
 
 [integration]
-yunohost = ">= 12.1.39"
+yunohost = ">= 12.1.40.1"
 helpers_version = "2.1"
 architectures = "all"
 multi_instance = true
@@ -58,8 +58,8 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    url = "https://github.com/ether/etherpad-lite/archive/refs/tags/3.3.0.tar.gz"
-    sha256 = "116f43e60e9cf74004a98405cfd5e02a1da6ad26130fde7c4a476cdc575a8551"
+    url = "https://github.com/ether/etherpad-lite/archive/refs/tags/3.3.1.tar.gz"
+    sha256 = "3295e664a38b5df95bf1f6ece7a54d4e925ff3a341c200ffef0681bd0483ab09"
     autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Etherpad"
 description.en = "Collaborative editing in real-time"
 description.fr = "Édition collaborative en temps réel"
 
-version = "3.2.0~ynh1"
+version = "3.3.0~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -58,8 +58,8 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    url = "https://github.com/ether/etherpad-lite/archive/refs/tags/3.2.0.tar.gz"
-    sha256 = "eb89c7be586d5793f5ba74eb1e891c2992a883b732872d74c14d55d556b0e932"
+    url = "https://github.com/ether/etherpad-lite/archive/refs/tags/3.3.0.tar.gz"
+    sha256 = "116f43e60e9cf74004a98405cfd5e02a1da6ad26130fde7c4a476cdc575a8551"
     autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]

--- a/manifest.toml
+++ b/manifest.toml
@@ -19,7 +19,7 @@ admindoc = "https://etherpad.org/doc/v3.3.1/index.html"
 code = "https://github.com/ether/etherpad-lite"
 
 [integration]
-yunohost = ">= 12.1.40.1"
+yunohost = ">= 12.1.39"
 helpers_version = "2.1"
 architectures = "all"
 multi_instance = true


### PR DESCRIPTION
Upgrade sources

* main v3.3.1: https://github.com/ether/etherpad-lite/releases/tag/3.3.1

Upgraded to version 3.3.1. Updated Yunohost to 12.1.40.1 from 12.1.39. Changed docs link from https://etherpad.org/doc/v2.2.7/ to https://etherpad.org/doc/v3.3.1/index.html